### PR TITLE
Add overriden styles for corporate colors

### DIFF
--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -3,6 +3,9 @@
 @import "decidim/utils/settings";
 @import "decidim/utils/settings";
 
+@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab&display=swap');
+
 $grey_suara: #443F3F;
 $grey_suara_rgb: rgb(68,63,63);
 $orange_suara: #F88F58;
@@ -14,6 +17,11 @@ $anchor-color-hover: scale-color($orange_suara, $lightness: -14%);
 body{
   background: $white !important;
   background-color: $white !important;
+  font-family: 'Roboto', Arial, 'Open Sans', sans-serif;
+}
+
+h1, .h1, h2, .h2, h3, .h3{
+  font-family: 'Roboto Slab', 'Roboto', Arial, 'Open Sans', sans-serif;
 }
 
 // HEADER

--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -1,0 +1,213 @@
+@import "decidim/variables";
+@import "foundation";
+@import "decidim/utils/settings";
+@import "decidim/utils/settings";
+
+$grey_suara: #443F3F;
+$grey_suara_rgb: rgb(68,63,63);
+$orange_suara: #F88F58;
+$orange_suara_rgb: rgb(248,143,88);
+
+$anchor-color: $grey_suara;
+$anchor-color-hover: scale-color($orange_suara, $lightness: -14%);
+
+
+// HEADER
+/////////////////////////////////
+.title-bar {
+  background: $white;
+}
+
+.topbar__search input, .topbar__search input:focus, .topbar__search input::placeholder{
+  background: $white;
+  color: $grey_suara;
+}
+
+.topbar__search input, .topbar__search input:focus{
+  border: 1px solid $medium-gray;
+}
+
+.logo-wrapper span{
+  color: $grey_suara !important;
+  &:before{
+    border-left-color: $grey_suara !important;
+  }
+}
+
+.topbar__dropmenu > ul > li > a{
+  color: $grey_suara;
+  &::after{
+    border-top-color: $grey_suara !important;
+  }
+}
+
+.topbar__user__login a{
+  color: $grey_suara;
+  &:hover{
+    color: $orange_suara;
+  }
+  &::before{
+    border-left: $grey_suara;
+  }
+}
+
+.dropdown.menu .is-active > a{
+  color: $orange_suara;
+  &::after{
+    border-top-color: $orange_suara !important;
+  }
+}
+
+
+.topbar__dropmenu .is-dropdown-submenu li a{
+  color: $grey_suara;
+  &:hover{
+    color: $orange_suara;
+  }
+}
+
+.topbar__dropmenu .is-dropdown-submenu{
+  &::after{
+    border-bottom-color: rgba($orange_suara, .05);
+  }
+  & li:hover{
+    background-color: rgba($orange_suara, .05);
+  }
+}
+
+.topbar__edit__link a{
+  color: $grey_suara;
+  &:hover{
+    color: $orange_suara;
+  }
+}
+
+.topbar__notifications, .topbar__conversations{
+  & .icon{
+    fill: $grey_suara;
+  }
+  &:hover .icon{
+    fill: $orange_suara;
+  }
+}
+
+// MENU
+/////////////////////////////////
+
+.navbar{
+  background: $light-gray-dark;
+}
+
+.main-nav__link--active a{
+  color: $grey_suara;
+}
+.main-nav__link a{
+  color: $grey_suara_rgb;
+  &:hover{
+    background: rgba($grey_suara_rgb, 0.02);
+    color: $orange_suara;
+  }
+}
+
+// FOOTER
+/////////////////////////////////
+
+.main-footer{
+  background-color: $white;
+}
+
+.main-footer a{
+  color: $grey_suara;
+  
+  &:hover{
+    color: $orange_suara;
+  }
+}
+.mini-footer a:hover{
+  color: $orange_suara;
+}
+
+// CONTENT
+////////////////////
+a{
+  color: $anchor-color;
+  &:hover{
+    color: $anchor-color-hover;
+  }
+  &:focus{
+    color: $anchor-color-hover;
+  }
+}
+
+.author-data .author__name{
+    color: $orange_suara;
+    &:hover{
+      color: $orange_suara;
+    }
+}
+
+.card__link{
+    color: $anchor-color;
+    &:hover{
+      color: $anchor-color-hover;
+    }
+}
+
+.link{
+  color: $anchor-color;
+  &:hover{
+    color: $anchor-color-hover;
+  }
+}
+
+.card--list__data__icon:hover .icon, .card--list__data__icon--lg:hover .icon{
+  fill: $anchor-color-hover;
+}
+
+
+.button.hollow.secondary:hover, .button.hollow.secondary:focus{
+  border-color: $anchor-color-hover;
+  color: $anchor-color-hover;
+}
+
+.accountability .categories .categories--group .card__link .category--line strong{
+  color: $anchor-color;
+}
+.accountability .categories .categories--group .card__link:hover strong{
+  color: $anchor-color-hover;
+}
+
+.author-data a:hover, .author-data button:hover{
+  color: $anchor-color-hover;
+}
+
+.pagination .current{
+  background-color: $anchor-color-hover;
+}
+
+.orgchart .as-text{
+  fill: $anchor-color-hover;
+}
+
+#profile-tabs.tabs .tabs-title a{
+  color: $anchor-color;
+}
+
+.dropdown.menu > li.is-dropdown-submenu-parent > a::after{
+  border-color: $grey_suara transparent transparent;
+}
+
+// FLOATING HELP
+//////////////////////
+.floating-helper__content{
+  border-top-color: $orange_suara; 
+  background-color: rgba($orange_suara_rgb, 0.1);
+}
+.floating-helper__content-close{
+  background-color: $orange_suara;
+}
+.floating-helper__icon-big{
+  color: $orange_suara;
+  background-color: rgba($orange_suara_rgb, 0.1);
+}
+

--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -5,6 +5,7 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Slab&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed&display=swap');
 
 $grey_suara: #443F3F;
 $grey_suara_rgb: rgb(68,63,63);
@@ -212,6 +213,10 @@ a{
 
 .dropdown.menu > li.is-dropdown-submenu-parent > a::after{
   border-color: $grey_suara transparent transparent;
+}
+
+.card--widget .card-data .card-data__item:first-child, .card .card__text time{
+  font-family: 'Roboto Condensed', 'Roboto', Arial, 'Open Sans', sans-serif;
 }
 
 // FLOATING HELP

--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -11,6 +11,10 @@ $orange_suara_rgb: rgb(248,143,88);
 $anchor-color: $grey_suara;
 $anchor-color-hover: scale-color($orange_suara, $lightness: -14%);
 
+body{
+  background: $white !important;
+  background-color: $white !important;
+}
 
 // HEADER
 /////////////////////////////////
@@ -129,6 +133,11 @@ $anchor-color-hover: scale-color($orange_suara, $lightness: -14%);
 
 // CONTENT
 ////////////////////
+
+.home-section:nth-of-type(2n){
+  background-color: $white;
+}
+
 a{
   color: $anchor-color;
   &:hover{


### PR DESCRIPTION
#### :tophat: What? Why?
Adding styles to use corporate colors on background, links and others

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Screenshot_2020-08-18 Kling Group](https://user-images.githubusercontent.com/5037794/90625959-9d0b1e00-e21a-11ea-9105-ed06541260c8.jpg)

![Captura de pantalla de 2020-08-18 18-53-43](https://user-images.githubusercontent.com/5037794/90626054-b7dd9280-e21a-11ea-91bb-06b5b1a4879f.png)

![Captura de pantalla de 2020-08-18 18-54-19](https://user-images.githubusercontent.com/5037794/90626083-c035cd80-e21a-11ea-9544-e2711f0cdd48.png)

![Captura de pantalla de 2020-08-18 18-55-11](https://user-images.githubusercontent.com/5037794/90626093-c461eb00-e21a-11ea-97d1-c42bd888960a.png)

