### PR TITLE
Hide assemblies and Organizational chart on assemblies index

### DIFF
--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -257,6 +257,11 @@ a{
   font-family: 'Roboto Condensed', 'Roboto', Arial, 'Open Sans', sans-serif;
 }
 
+main.wrapper{
+  section#parent-assemblies{display: none !important;}
+  section#assemblies-chart{display: none !important;}
+}
+
 // FLOATING HELP
 //////////////////////
 .floating-helper__content{


### PR DESCRIPTION
#### :tophat: What? Why?
Suara wants to hide the assemblies list and organization chart from assemblies and only show the highlighted ones

