### PR TITLE
Override highlighted assemblies order in index by title

### DIFF
--- a/app/queries/decidim/assemblies/assemblies_by_title.rb
+++ b/app/queries/decidim/assemblies/assemblies_by_title.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    # This query orders assemblies by importance, prioritizing promoted
+    # assemblies.
+    class AssembliesByTitle < Rectify::Query
+      def query
+        Decidim::Assembly.order(Arel.sql("title->'#{I18n.locale}' ASC"))
+      end
+    end
+  end
+end

--- a/app/queries/decidim/assemblies/organization_published_assemblies.rb
+++ b/app/queries/decidim/assemblies/organization_published_assemblies.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Assemblies
+    # This query class filters published assemblies given an organization.
+    class OrganizationPublishedAssemblies < Rectify::Query
+      def initialize(organization, user = nil)
+        @organization = organization
+        @user = user
+      end
+
+      def query
+        Rectify::Query.merge(
+          OrganizationAssemblies.new(@organization),
+          PublishedAssemblies.new,
+          VisibleAssemblies.new(@user),
+          AssembliesByTitle.new
+        ).query
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Set order on highlighted assemblies by title
