### PR TITLE
Change to fork in Decidim gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-DECIDIM_VERSION = { git: "https://github.com/decidim/decidim", branch: "release/0.22-stable" }
+DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim", branch: "release/0.22-stable" }
 
 ruby RUBY_VERSION
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,6 @@
 GIT
-  remote: https://github.com/CodiTramuntana/decidim-module-term_customizer
-  revision: c4ed0ffa87bd9977c6b470aa815d5dc2ed9f88a5
-  specs:
-    decidim-term_customizer (0.18.0)
-      decidim-admin (>= 0.18.0)
-      decidim-core (>= 0.18.0)
-
-GIT
-  remote: https://github.com/coopdevs/decidim-module-action_delegator
-  revision: edcd01221f1e52662392ce83c4307af051148681
-  specs:
-    decidim-action_delegator (0.1)
-      decidim-admin (= 0.22.0)
-      decidim-consultations (= 0.22.0)
-      decidim-core (= 0.22.0)
-      savon
-      twilio-ruby
-
-GIT
-  remote: https://github.com/decidim/decidim
-  revision: 4d151061e4cd418392235b214641bb1a471b8606
+  remote: https://github.com/CodiTramuntana/decidim
+  revision: 4bcc4a70a0e8fbf10b5c7e9ce39575a3bd924e3e
   branch: release/0.22-stable
   specs:
     decidim (0.22.0)
@@ -221,6 +202,25 @@ GIT
       decidim-core (= 0.22.0)
 
 GIT
+  remote: https://github.com/CodiTramuntana/decidim-module-term_customizer
+  revision: c4ed0ffa87bd9977c6b470aa815d5dc2ed9f88a5
+  specs:
+    decidim-term_customizer (0.18.0)
+      decidim-admin (>= 0.18.0)
+      decidim-core (>= 0.18.0)
+
+GIT
+  remote: https://github.com/coopdevs/decidim-module-action_delegator
+  revision: edcd01221f1e52662392ce83c4307af051148681
+  specs:
+    decidim-action_delegator (0.1)
+      decidim-admin (= 0.22.0)
+      decidim-consultations (= 0.22.0)
+      decidim-core (= 0.22.0)
+      savon
+      twilio-ruby
+
+GIT
   remote: https://github.com/gencat/decidim-verifications-members_picker.git
   revision: c72facbc79dd4c4d8753a1330a6978ad7259f746
   tag: 0.0.2
@@ -232,25 +232,25 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (5.2.4.4)
-      actionpack (= 5.2.4.4)
+    actioncable (5.2.4.5)
+      actionpack (= 5.2.4.5)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailer (5.2.4.4)
-      actionpack (= 5.2.4.4)
-      actionview (= 5.2.4.4)
-      activejob (= 5.2.4.4)
+    actionmailer (5.2.4.5)
+      actionpack (= 5.2.4.5)
+      actionview (= 5.2.4.5)
+      activejob (= 5.2.4.5)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (5.2.4.4)
-      actionview (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    actionpack (5.2.4.5)
+      actionview (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.4.4)
-      activesupport (= 5.2.4.4)
+    actionview (5.2.4.5)
+      activesupport (= 5.2.4.5)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
@@ -258,20 +258,20 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
-    activejob (5.2.4.4)
-      activesupport (= 5.2.4.4)
+    activejob (5.2.4.5)
+      activesupport (= 5.2.4.5)
       globalid (>= 0.3.6)
-    activemodel (5.2.4.4)
-      activesupport (= 5.2.4.4)
-    activerecord (5.2.4.4)
-      activemodel (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    activemodel (5.2.4.5)
+      activesupport (= 5.2.4.5)
+    activerecord (5.2.4.5)
+      activemodel (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       arel (>= 9.0)
-    activestorage (5.2.4.4)
-      actionpack (= 5.2.4.4)
-      activerecord (= 5.2.4.4)
+    activestorage (5.2.4.5)
+      actionpack (= 5.2.4.5)
+      activerecord (= 5.2.4.5)
       marcel (~> 0.3.1)
-    activesupport (5.2.4.4)
+    activesupport (5.2.4.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -298,7 +298,7 @@ GEM
       execjs (~> 2.0)
     batch-loader (1.5.0)
     bcrypt (3.1.16)
-    better_html (1.0.15)
+    better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
       ast (~> 2.0)
@@ -312,7 +312,7 @@ GEM
     browser (2.7.1)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.35.0)
+    capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -353,7 +353,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    css_parser (1.8.0)
+    css_parser (1.9.0)
       addressable
     daemons (1.3.1)
     date_validator (0.9.0)
@@ -396,7 +396,7 @@ GEM
     docile (1.3.5)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    doorkeeper (5.4.0)
+    doorkeeper (5.5.0)
       railties (>= 5)
     doorkeeper-i18n (4.0.1)
     equalizer (0.0.11)
@@ -426,7 +426,7 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
-    ffi (1.14.2)
+    ffi (1.15.0)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
     file_validators (2.3.0)
@@ -442,13 +442,13 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.6.4)
+    geocoder (1.6.6)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.11)
       railties
       sprockets-rails
-    graphql (1.12.1)
+    graphql (1.12.5)
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (1.0.1)
@@ -467,7 +467,7 @@ GEM
       socksify
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
-    i18n-tasks (0.9.33)
+    i18n-tasks (0.9.34)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       erubi
@@ -543,7 +543,7 @@ GEM
     mixlib-cli (2.1.8)
     mixlib-config (3.0.9)
       tomlrb
-    mixlib-shellout (3.2.2)
+    mixlib-shellout (3.2.5)
       chef-utils
     msgpack (1.3.3)
     multi_json (1.15.0)
@@ -551,7 +551,7 @@ GEM
     multipart-post (2.1.1)
     mustache (1.1.1)
     netrc (0.11.0)
-    nio4r (2.5.4)
+    nio4r (2.5.7)
     nobspw (0.6.2)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
@@ -574,9 +574,9 @@ GEM
       oauth2 (~> 1.1)
       omniauth (>= 1.1.1)
       omniauth-oauth2 (>= 1.6)
-    omniauth-oauth (1.1.0)
+    omniauth-oauth (1.2.0)
       oauth
-      omniauth (~> 1.0)
+      omniauth (>= 1.0, < 3)
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
@@ -610,24 +610,24 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
-    rack-attack (6.4.0)
+    rack-attack (6.5.0)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rails (5.2.4.4)
-      actioncable (= 5.2.4.4)
-      actionmailer (= 5.2.4.4)
-      actionpack (= 5.2.4.4)
-      actionview (= 5.2.4.4)
-      activejob (= 5.2.4.4)
-      activemodel (= 5.2.4.4)
-      activerecord (= 5.2.4.4)
-      activestorage (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    rails (5.2.4.5)
+      actioncable (= 5.2.4.5)
+      actionmailer (= 5.2.4.5)
+      actionpack (= 5.2.4.5)
+      actionview (= 5.2.4.5)
+      activejob (= 5.2.4.5)
+      activemodel (= 5.2.4.5)
+      activerecord (= 5.2.4.5)
+      activestorage (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       bundler (>= 1.3.0)
-      railties (= 5.2.4.4)
+      railties (= 5.2.4.5)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
@@ -641,9 +641,9 @@ GEM
     rails-i18n (5.1.3)
       i18n (>= 0.7, < 2)
       railties (>= 5.0, < 6)
-    railties (5.2.4.4)
-      actionpack (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    railties (5.2.4.5)
+      actionpack (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
@@ -665,7 +665,7 @@ GEM
       wisper (>= 1.6.1)
     redcarpet (3.5.1)
     redis (4.2.5)
-    regexp_parser (2.0.3)
+    regexp_parser (2.1.1)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.1)
@@ -760,7 +760,7 @@ GEM
     social-share-button (1.2.3)
       coffee-rails
     socksify (1.7.1)
-    spreadsheet (1.2.7)
+    spreadsheet (1.2.8)
       ruby-ole
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
@@ -781,7 +781,7 @@ GEM
     system_test_html_screenshots (0.1.2)
       actionpack (>= 5.2, < 6.0.a)
     temple (0.8.2)
-    terminal-table (2.0.0)
+    terminal-table (3.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (1.1.0)
     thread_safe (0.3.6)
@@ -824,7 +824,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.11.1)
+    webmock (3.12.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/db/migrate/20210308152646_add_weight_field_to_participatory_processes.decidim_participatory_processes.rb
+++ b/db/migrate/20210308152646_add_weight_field_to_participatory_processes.decidim_participatory_processes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_participatory_processes (originally 20210204154593)
+
+class AddWeightFieldToParticipatoryProcesses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_participatory_processes, :weight, :integer, null: false, default: true
+  end
+end

--- a/db/migrate/20210308152647_add_weight_field_to_assembly.decidim_assemblies.rb
+++ b/db/migrate/20210308152647_add_weight_field_to_assembly.decidim_assemblies.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+# This migration comes from decidim_assemblies (originally 20210204152393)
+
+class AddWeightFieldToAssembly < ActiveRecord::Migration[5.2]
+  def change
+    add_column :decidim_assemblies, :weight, :integer, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_21_093337) do
+ActiveRecord::Schema.define(version: 2021_03_08_152647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 2020_12_21_093337) do
     t.string "youtube_handler"
     t.string "github_handler"
     t.bigint "decidim_assemblies_type_id"
+    t.integer "weight", default: 1, null: false
     t.index ["decidim_area_id"], name: "index_decidim_assemblies_on_decidim_area_id"
     t.index ["decidim_assemblies_type_id"], name: "index_decidim_assemblies_on_decidim_assemblies_type_id"
     t.index ["decidim_organization_id", "slug"], name: "index_unique_assembly_slug_and_organization", unique: true
@@ -1106,6 +1107,7 @@ ActiveRecord::Schema.define(version: 2020_12_21_093337) do
     t.bigint "decidim_area_id"
     t.bigint "decidim_scope_type_id"
     t.boolean "show_metrics", default: true
+    t.integer "weight", default: 1, null: false
     t.index ["decidim_area_id"], name: "index_decidim_participatory_processes_on_decidim_area_id"
     t.index ["decidim_organization_id", "slug"], name: "index_unique_process_slug_and_organization", unique: true
     t.index ["decidim_organization_id"], name: "index_decidim_processes_on_decidim_organization_id"


### PR DESCRIPTION
#### :tophat: What? Why?
Gem Decidim is changed to the fork in branch release/0.22-stable. In this way, the order of assemblies and processes is added.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add `CHANGELOG` entry
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Add tests
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
