### PR TITLE
Change link in invitation email

### DIFF
--- a/app/views/devise/mailer/invite_private_user.html.erb
+++ b/app/views/devise/mailer/invite_private_user.html.erb
@@ -2,7 +2,7 @@
 
 <p><%= t("mailer.suara.invitation_instructions.space_already") %></p>
 
-<p><%= t("mailer.suara.invitation_instructions.accept") %> <%= link_to t("mailer.suara.invitation_instructions.here"), accept_invitation_url(@resource, invitation_token: @token, host: @resource.organization.host) %> <%= t("mailer.suara.invitation_instructions.credentials") %></p>
+<p><%= t("mailer.suara.invitation_instructions.accept") %> <%= link_to t("mailer.suara.invitation_instructions.here"), root_url(host: @organization.host) %> <%= t("mailer.suara.invitation_instructions.credentials") %></p>
 
 <p><%= t("mailer.suara.invitation_instructions.contact_with") %> <%= mail_to "participacio@suara.coop" %>.</p>
 


### PR DESCRIPTION
#### :tophat: What? Why?
The link in the email has been changed.

Before it redirects you to finish the registration and now it redirects you to the home page.

#### :clipboard: Subtasks
- [ ] Add tests
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
