### PR TITLE
Change nickname to the same name in email

### DIFF
--- a/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -16,6 +16,7 @@ module Decidim
 
         @form = form(OmniauthRegistrationForm).from_params(form_params)
         @form.email ||= verified_email
+        @form.nickname ||= verified_email.split("@").first.parameterize(separator: "_")
 
         CreateOmniauthRegistration.call(@form, verified_email) do
           on(:ok) do |user|
@@ -94,7 +95,6 @@ module Decidim
           provider: oauth_data[:provider],
           uid: oauth_data[:uid],
           name: oauth_data[:info][:name],
-          nickname: oauth_data[:info][:nickname],
           oauth_signature: OmniauthRegistrationForm.create_signature(oauth_data[:provider], oauth_data[:uid]),
           avatar_url: oauth_data[:info][:image],
           raw_data: oauth_hash

--- a/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable Rspec/AnyInstance
+module Decidim
+  describe Decidim::Devise::OmniauthRegistrationsController, type: :controller do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:sap_response) do
+      {
+        ceco: "ceco",
+        ceco_txt: "ceco_txt",
+        tipologia: "tipologia",
+        grup_empleados: "grup_empleados",
+        estat_soci: "estat_soci",
+        derechovoto: "derechovoto",
+        estat_ocup: "estat_ocup"
+      }
+    end
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      request.env["devise.mapping"] = ::Devise.mappings[:user]
+      allow_any_instance_of(SapAuthorizationHandler).to receive(:metadata).and_return(sap_response)
+    end
+
+    describe "POST create" do
+      let(:provider) { "google" }
+      let(:uid) { "12345" }
+      let(:email) { "best_user@from-google.com" }
+
+      before do
+        request.env["omniauth.auth"] = {
+          provider: provider,
+          uid: uid,
+          info: {
+            name: "Google User",
+            email: email
+          }
+        }
+      end
+
+      context "when the unverified email address is already in use" do
+        before do
+          post :create
+        end
+
+        it "doesn't create a new user" do
+          expect(User.count).to eq(1)
+        end
+
+        it "logs in" do
+          expect(controller).to be_user_signed_in
+        end
+      end
+
+      context "when the unverified email address is already in use but left unconfirmed" do
+        let!(:user) { create(:user, organization: organization, email: email) }
+
+        before do
+          user.update!(
+            confirmation_sent_at: Time.now.utc - 1.year
+          )
+        end
+
+        context "with the same email as from the identity provider" do
+          before do
+            post :create
+          end
+
+          it "logs in" do
+            expect(controller).to be_user_signed_in
+          end
+
+          it "confirms the user account" do
+            expect(controller.current_user).to be_confirmed
+          end
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Rspec/AnyInstance


### PR DESCRIPTION
#### :tophat: What? Why?
Change nickname to the same email name in order to avoid errors in nickname like blank spaces.

#### :clipboard: Subtasks
- [ ] Add tests
- [ ] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Another subtask

### :camera: Screenshots (optional)
![Description](URL)
