### PR TITLE
Remember to remove doorkeeper initializer after Decidim v0.28

### DIFF
--- a/spec/features/overrides_and_customizations_spec.rb
+++ b/spec/features/overrides_and_customizations_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Overrides and customizations" do
+  it "remove config/initializers/doorkeeper.rb after Decidim v0.28" do
+    # remove config/initializers/doorkeeper.rb after Decidim v0.28 as it is already initialized in that version
+    expect(Decidim.version).to be < "0.28"
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Remember to remove doorkeeper initializer after upgrading to Decidim v0.28.
