### PR TITLE
Improvement Consultation public view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "decidim", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION
 gem "decidim-verifications", DECIDIM_VERSION
 
-gem "decidim-action_delegator", git: "https://github.com/CodiTramuntana/decidim-module-action_delegator.git", branch: "upgrade/decidim-0_26"
+gem "decidim-action_delegator", git: "https://github.com/CodiTramuntana/decidim-module-action_delegator.git", branch: "feat/text_link_delegations"
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 gem "virtus-multiparams"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/CodiTramuntana/decidim-module-action_delegator.git
-  revision: bc082387fb4cc442c2e9ad5ffc66f51ad19678e1
-  branch: upgrade/decidim-0_26
+  revision: 5a4fa7da676c12d8fe600045f97cfc4269519f6d
+  branch: feat/text_link_delegations
   specs:
     decidim-action_delegator (0.6.0)
       decidim-admin (>= 0.26.0, < 0.27.0)
@@ -778,7 +778,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.11)
     tomlrb (2.0.3)
-    twilio-ruby (5.72.0)
+    twilio-ruby (5.73.0)
       faraday (>= 0.9, < 3.0)
       jwt (>= 1.5, <= 2.5)
       nokogiri (>= 1.6, < 2.0)

--- a/README.md
+++ b/README.md
@@ -68,13 +68,19 @@ The following files must be checked in each upgrade of Decidim.
 ----------
 - app/views/decidim/consultations/questions/show.html.erb
 
-### Consultations: add hours to voting dates
+### Consultations 
+
+## Add hours to voting dates
 
 - app/decorators/forms/decidim/consultations/admin/consultation_form_decorator.rb
 - app/decorators/models/decidim/consultation_decorator.rb
 ----------
 - app/overrides/decidim/consultations/admin/change_voting_date_to_datetime_field_in_consultations_form.rb
 - app/overrides/layouts/decidim/add_format_to_start_voting_date_in_show.rb
+
+## Add questions left to response
+
+- app/overrides/layouts/decidim/add_questions_left_to_response.rb
 
 ### Override Quill editor
 - app/packs/src/decidim/editor.js

--- a/app/decorators/controllers/decidim/consultations/consultations_controller_decorator.rb
+++ b/app/decorators/controllers/decidim/consultations/consultations_controller_decorator.rb
@@ -35,4 +35,8 @@ Decidim::Consultations::ConsultationsController.class_eval do
 
     @questions_left_to_response = (questions - response_questions).count
   end
+
+  def current_participatory_space
+    current_consultation unless action_name == "index"
+  end
 end

--- a/app/decorators/controllers/decidim/consultations/consultations_controller_decorator.rb
+++ b/app/decorators/controllers/decidim/consultations/consultations_controller_decorator.rb
@@ -6,6 +6,9 @@ Decidim::Consultations::ConsultationsController.class_eval do
   include SuaraPermissionsSupervisor
 
   alias_method :original_show, :show
+
+  before_action :questions_left_to_response, only: :show
+
   def show
     original_show
     render status: :forbidden unless admin_or_with_suara_permissions?(current_user, current_participatory_space)
@@ -23,5 +26,13 @@ Decidim::Consultations::ConsultationsController.class_eval do
       @consultations = Decidim::Consultation.where(id: @consultations.map(&:id))
       @consultations = paginate(@consultations)
     end
+  end
+
+  def questions_left_to_response
+    questions = current_consultation.questions.pluck(:id)
+    response_questions = Decidim::Consultations::Vote.where(decidim_consultation_question_id: current_consultation.questions.pluck(:id),
+                                                            decidim_author_id: current_user).pluck(:decidim_consultation_question_id)
+
+    @questions_left_to_response = (questions - response_questions).count
   end
 end

--- a/app/overrides/layouts/decidim/add_questions_left_to_response.rb
+++ b/app/overrides/layouts/decidim/add_questions_left_to_response.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Deface::Override.new(virtual_path: "layouts/decidim/_consultation_header",
+                     original: "7cb40dc66937aa6148059453ec6c30b7d5bfe718",
+                     name: "add_questions_left_to_response",
+                     insert_after: "p.text-highlight",
+                     text: "
+                      <div class='questions-left-to-response'>
+                        <span><%= t('.questions_left_to_response') %>:</span>
+                        <span><%= @questions_left_to_response %>/<%= current_consultation.questions.size %></span>
+                      </div>
+                    ")

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -232,12 +232,6 @@ a{
   color: #fff;
 }
 
-.card--full__image {
-  .button.expanded.button--sc {
-    display: none;
-  }
-}
-
 .card--list__data__icon:hover .icon, .card--list__data__icon--lg:hover .icon{
   fill: $anchor-color-hover;
 }
@@ -365,4 +359,22 @@ div.section#highlighted-questions{
 .consultation__questions-button {
   display: flex !important;
   justify-content: end;
+}
+
+.question-vote-cabin .delegations-notice a {
+  margin-top: 0.5rem;
+  background-color: $orange-suara-dark !important;
+  color: #fff !important;
+  border-radius: 4px;
+}
+
+.questions-left-to-response {
+  width: 16rem;
+  padding: 4px;
+  margin-top: 2rem;
+  background-color: $orange_suara;
+  border-radius: 4px;
+  font-size: 18px;
+  font-weight: bold;
+  color: #fff;
 }

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -92,6 +92,8 @@ ca:
         question:
           attachments: Adjunts
           categories: Categories
+      consultation_header:
+        questions_left_to_response: Preguntes per respondre
       question_header:
         return_to_questions: Tornar al llistat de preguntes
   permissions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,8 @@ en:
         question:
           attachments: Attachments
           categories: Categories
+      consultation_header:
+        questions_left_to_response: Questions left to response
       question_header:
         return_to_questions: Back to questions list
   permissions:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -92,6 +92,8 @@ es:
         question:
           attachments: Adjuntos
           categories: Categorías
+      consultation_header:
+        questions_left_to_response: Preguntas por responder
       question_header:
         return_to_questions: Volver al listado de preguntas
   permissions:

--- a/spec/system/decidim/consultations/consultation_spec.rb
+++ b/spec/system/decidim/consultations/consultation_spec.rb
@@ -5,7 +5,8 @@ require "rails_helper"
 describe "Consultation", type: :system do
   let!(:organization) { create(:organization) }
   let!(:consultation) { create(:consultation, :published, organization: organization, start_voting_date: Time.zone.now) }
-  let!(:user) { create :user, :confirmed, organization: organization }
+  let!(:user) { create :user, :admin, :confirmed, organization: organization }
+  let!(:question) { create :question, consultation: consultation, scope: consultation.highlighted_scope }
 
   before do
     switch_to_host(organization.host)
@@ -22,7 +23,6 @@ describe "Consultation", type: :system do
 
     context "when the end voting date is later than now" do
       let(:consultation) { create(:consultation, :published, organization: organization, start_voting_date: Time.zone.local(2022, 9, 21, 9, 0, 0), end_voting_date: Time.zone.local(2022, 9, 21, 15, 0, 0)) }
-      let(:question) { create :question, consultation: consultation }
 
       before do
         allow(Time.zone).to receive(:now).and_return(Time.zone.local(2022, 9, 21, 11, 0, 0))
@@ -36,7 +36,6 @@ describe "Consultation", type: :system do
 
     context "when the end voting date is earlier than now" do
       let(:consultation) { create(:consultation, :published, organization: organization, start_voting_date: Time.zone.local(2022, 9, 21, 9, 0, 0), end_voting_date: Time.zone.local(2022, 9, 21, 15, 0, 0)) }
-      let(:question) { create :question, consultation: consultation }
 
       before do
         allow(Time.zone).to receive(:now).and_return(Time.zone.local(2022, 9, 21, 15, 0o5, 0))
@@ -45,6 +44,33 @@ describe "Consultation", type: :system do
 
       it "user can not vote a question in consultation" do
         expect(page).not_to have_content("Vote")
+      end
+    end
+
+    context "and show questions left to response" do
+      before do
+        switch_to_host(organization.host)
+        login_as user, scope: :user
+      end
+
+      it "show 1/1 left to response without votes" do
+        expect(page).to have_content("Questions left to response: 1/1")
+      end
+
+      context "and question has one vote" do
+        let!(:response) { create :response, question: question }
+
+        before do
+          visit decidim_consultations.question_path(question)
+          click_link(id: "vote_button")
+          click_button translated(response.title)
+          click_button "Confirm"
+          visit decidim_consultations.consultation_path(consultation)
+        end
+
+        it "show 0/1 left to response with a response" do
+          expect(page).to have_content("Questions left to response: 0/1")
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds improvements to how Consultations are displayed:

### Improvements from action delegator (https://github.com/coopdevs/decidim-module-action_delegator/pull/119):

- In the "Tens delegacions disponibles" buttons, if you have answered, it appears as "Vot delegat realitzat".

![imagen](https://user-images.githubusercontent.com/75725233/196674812-501b8011-f535-4244-9140-94527ef3633f.png)

![Captura de pantalla de 2022-10-18 12-07-30](https://user-images.githubusercontent.com/75725233/196661343-7e977696-6f75-45c8-802f-1d7a6fb308cb.png)

### Suara Improvements:
- A counter of not responded questions shows after Consultation title.

![imagen](https://user-images.githubusercontent.com/75725233/196674740-4af6cf88-578a-4804-a41a-b192fcfaa09d.png)


#### :clipboard: Subtasks
- [x] Add tests
- [x] Add documentation regarding the feature 
- [ ] Add/modify seeds
- [ ] Another subtask


