### PR TITLE
Fix blank vote JS webpack importations

### DIFF
--- a/app/overrides/decidim/consultations/admin/responses/add_blank_vote_to_consultations_responses_form.rb
+++ b/app/overrides/decidim/consultations/admin/responses/add_blank_vote_to_consultations_responses_form.rb
@@ -8,7 +8,6 @@ Deface::Override.new(virtual_path: "decidim/consultations/admin/responses/_form"
                         <% if current_question.blank_vote %>
                           <%= form.check_box :blank_vote,
                           {
-                            onchange: 'blankVote(this)',
                             'data-attribute': (Hash[*current_question.organization.available_locales.map{ |locale| [locale, I18n.with_locale(locale.to_sym) { t('activemodel.attributes.response.blank_vote') }] }.flatten]).to_json
                           }
                            %>

--- a/app/overrides/decidim/consultations/admin/responses/add_js_to_consultations_responses_form.rb
+++ b/app/overrides/decidim/consultations/admin/responses/add_js_to_consultations_responses_form.rb
@@ -3,4 +3,4 @@
 Deface::Override.new(virtual_path: "decidim/consultations/admin/responses/_form",
                      name: "add_js_to_consultations_responses_form",
                      insert_before: "div.card",
-                     text: '<%= javascript_pack_tag "decidim/admin/blank_vote" %>')
+                     text: '<%= javascript_pack_tag "consultations_admin_blank_vote" %>')

--- a/app/overrides/decidim/consultations/admin/responses/add_js_to_edit_consultations_responses.rb
+++ b/app/overrides/decidim/consultations/admin/responses/add_js_to_edit_consultations_responses.rb
@@ -3,4 +3,4 @@
 Deface::Override.new(virtual_path: "decidim/consultations/admin/responses/edit",
                      name: "add_js_to_edit_consultations_response",
                      insert_before: "erb[loud]:contains('<%= decidim_form_for @form')",
-                     text: '<%= javascript_pack_tag "decidim/admin/blank_vote" %>')
+                     text: '<%= javascript_pack_tag "consultations_admin_blank_vote" %>')

--- a/app/packs/entrypoints/decidim/consultations/admin/blank_vote.js
+++ b/app/packs/entrypoints/decidim/consultations/admin/blank_vote.js
@@ -1,0 +1,1 @@
+import "src/decidim/consultations/admin/blank_vote"

--- a/app/packs/entrypoints/decidim/consultations/blank_vote.js
+++ b/app/packs/entrypoints/decidim/consultations/blank_vote.js
@@ -1,0 +1,1 @@
+import "src/decidim/consultations/blank_vote"

--- a/app/packs/src/decidim/consultations/admin/blank_vote.js
+++ b/app/packs/src/decidim/consultations/admin/blank_vote.js
@@ -1,12 +1,14 @@
-function blankVote(element) {
-  let translations = JSON.parse(element.getAttribute("data-attribute"));
+const checkboxBlankVote = document.querySelector('form input[type="checkbox"]');
 
-  if (element.checked === true) {
+checkboxBlankVote.addEventListener('change', function() {
+  let translations = JSON.parse(this.getAttribute("data-attribute"));
+  
+  if (this.checked === true) {
     getInputTitles(true, translations);
   } else {
     getInputTitles(false, translations);
   }
-}
+})
 
 function getInputTitles (blankVote, translations) {
   for (let i = 0; i < Object.keys(translations).length; i++) { 

--- a/app/packs/src/decidim/consultations/blank_vote.js
+++ b/app/packs/src/decidim/consultations/blank_vote.js
@@ -1,5 +1,6 @@
-function multipleVote(checkbox) {
-  const checkboxes = document.querySelectorAll('form .multiple_votes_form input[type="checkbox"]');
+const checkboxes = document.querySelectorAll('form .multiple_votes_form input[type="checkbox"]');
+
+checkboxes.forEach(checkbox => checkbox.addEventListener('change', function() {
   let remainingVotesCount = document.getElementById('remaining-votes-count');
   let max = parseInt(remainingVotesCount.textContent, 10);
 
@@ -26,4 +27,4 @@ function multipleVote(checkbox) {
       }
     });
   }
-}
+}));

--- a/app/packs/src/decidim/decidim_application.js
+++ b/app/packs/src/decidim/decidim_application.js
@@ -9,5 +9,3 @@ require.context("../../images", true)
 // If that JS file is replacing a Decidim file, there’s no need to add it to decidim_application.js
 
 import './target_links';
-import './admin/blank_vote';
-import './consultations/blank_vote';

--- a/app/views/decidim/consultations/question_multiple_votes/_form.html.erb
+++ b/app/views/decidim/consultations/question_multiple_votes/_form.html.erb
@@ -10,9 +10,11 @@
   <div class="card__content multiple_votes_form">
     <% responses.each do |response| %>
       <div>
-        <%= check_box_tag "responses[]", response.id, false, id: "vote_id_#{response.id}", blank_vote: response.blank_vote, onclick: "multipleVote(this)" %>
+        <%= check_box_tag "responses[]", response.id, false, id: "vote_id_#{response.id}", blank_vote: response.blank_vote %>
         <%= form.label :id, translated_attribute(response.title), for: "vote_id_#{response.id}" %>
       </div>
     <% end %>
   </div>
 </div>
+
+<%= javascript_pack_tag "consultations_blank_vote" %>

--- a/config/assets.rb
+++ b/config/assets.rb
@@ -19,7 +19,9 @@ Decidim::Webpacker.register_path("#{base_path}/app/packs")
 # SCSS files within the entrypoints, they become available for inclusion using
 # `stylesheet_pack_tag`.
 Decidim::Webpacker.register_entrypoints(
-  suara_email: "#{base_path}/app/packs/entrypoints/decidim/suara_email.js"
+  suara_email: "#{base_path}/app/packs/entrypoints/decidim/suara_email.js",
+  consultations_blank_vote: "#{base_path}/app/packs/entrypoints/decidim/consultations/blank_vote.js",
+  consultations_admin_blank_vote: "#{base_path}/app/packs/entrypoints/decidim/consultations/admin/blank_vote.js"
 )
 
 # If you want to import some extra SCSS files in the Decidim main SCSS file


### PR DESCRIPTION
#### :tophat: What? Why?
No JS referring to the blank vote was working because the webpack imports weren't doing it right.

