### PR TITLE
Get latest CSV emails verifier v0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "decidim-verifications", DECIDIM_VERSION
 
 gem "decidim-action_delegator", git: "https://github.com/CodiTramuntana/decidim-module-action_delegator.git", branch: "first_ite/import_delegations_csv"
 gem "decidim-term_customizer", git: "https://github.com/CodiTramuntana/decidim-module-term_customizer.git", branch: "fix/translation_set_query_consultations_question"
-gem "decidim-verifications-csv_email", git: "https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git", tag: "v0.1.0"
+gem "decidim-verifications-csv_email", git: "https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git", tag: "v0.1.1"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.4"
 
 gem "omniauth-rails_csrf_protection", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,10 +22,10 @@ GIT
 
 GIT
   remote: https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git
-  revision: 081ac7ee975040e83c607fc8b5f5891262196c23
-  tag: v0.1.0
+  revision: cacbfd10b315d2304f90e6401183a33dd80829a6
+  tag: v0.1.1
   specs:
-    decidim-verifications-csv_email (0.1.0)
+    decidim-verifications-csv_email (0.1.1)
       decidim (>= 0.25.2)
       decidim-admin (>= 0.25.2)
       decidim-verifications (>= 0.25.2)
@@ -908,4 +908,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.3.4
+   2.3.6


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates `decidim-verifications-csv_email` to fix the problem that this verificator has when used together with another verificator in the same component.
