### PR TITLE
Fix SuaraPermissionsSupervisor to only select SAP authorizations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "decidim-consultations", DECIDIM_VERSION
 gem "decidim-verifications", DECIDIM_VERSION
 
 gem "decidim-action_delegator", git: "https://github.com/CodiTramuntana/decidim-module-action_delegator.git", branch: "first_ite/import_delegations_csv"
-gem "decidim-term_customizer", git: "https://github.com/CodiTramuntana/decidim-module-term_customizer.git", branch: "fix/translation_set_query_consultations_question"
+gem "decidim-term_customizer", git: "https://github.com/CodiTramuntana/decidim-module-term_customizer.git", branch: "fix/translation_set_query_consultations"
 gem "decidim-verifications-csv_email", git: "https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git", tag: "v0.1.1"
 gem "decidim-verifications-members_picker", git: "https://github.com/gencat/decidim-verifications-members_picker.git", tag: "0.0.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,8 @@ GIT
 
 GIT
   remote: https://github.com/CodiTramuntana/decidim-module-term_customizer.git
-  revision: 71454471cc45e170e2d5227657f3e20b4afb2e29
-  branch: fix/translation_set_query_consultations_question
+  revision: 72560d0f287adb33b57a28fb9a3a02fd8a01724e
+  branch: fix/translation_set_query_consultations
   specs:
     decidim-term_customizer (0.26.0)
       decidim-admin (~> 0.26.0)

--- a/app/permissions/suara_permissions_supervisor.rb
+++ b/app/permissions/suara_permissions_supervisor.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+# This Supervisor checks User's permissions from SAP.
 module SuaraPermissionsSupervisor
   # Checks whether the given `user` has the same permissions as the given `participatory_space`.
   def suara_permissions_match?(user, participatory_space)
-    user_auth = Decidim::Authorization.find_by(decidim_user_id: user.id)
+    user_auth = Decidim::Authorization.find_by(decidim_user_id: user.id, name: "sap_authorization_handler")
     user_permissions = user_auth&.metadata || {}
     space_permissions= participatory_space.suara_permissions
     # space permissions should be a subgroup of user permissions (ignoring empty keys)

--- a/app/permissions/suara_permissions_supervisor.rb
+++ b/app/permissions/suara_permissions_supervisor.rb
@@ -12,7 +12,7 @@ module SuaraPermissionsSupervisor
   end
 
   def filter_by_suara_permissions(participatory_spaces)
-    user_auth = Decidim::Authorization.find_by(decidim_user_id: current_user)
+    user_auth = Decidim::Authorization.find_by(decidim_user_id: current_user, name: "sap_authorization_handler")
     user_permissions = user_auth.present? && user_auth.metadata.present? ? user_auth.metadata : {}
 
     without_permissions(participatory_spaces) + filter_by_permissions(participatory_spaces, user_permissions)

--- a/lib/tasks/sap_update_authorizations.rake
+++ b/lib/tasks/sap_update_authorizations.rake
@@ -10,7 +10,8 @@ namespace :sap do
       )
       Decidim::CreateSapAuthorization.call(authorization) do
         on(:ok) do
-          Rails.logger.info "UpdateMetadata: --- INFO: USER #id: #{user.id} -> Authorization updated at: #{Decidim::Authorization.find_by(decidim_user_id: user.id, name: "sap_authorization_handler").updated_at}"
+          authorization= Decidim::Authorization.find_by(decidim_user_id: user.id, name: "sap_authorization_handler")
+          Rails.logger.info "UpdateMetadata: --- INFO: USER #id: #{user.id} -> Authorization updated at: #{authorization.updated_at}"
         end
         on(:invalid) do
           Rails.logger.info "UpdateMetadata: --- INFO: authorization is invalid and can't be created for the user #id: #{user.id}."

--- a/lib/tasks/sap_update_authorizations.rake
+++ b/lib/tasks/sap_update_authorizations.rake
@@ -10,7 +10,7 @@ namespace :sap do
       )
       Decidim::CreateSapAuthorization.call(authorization) do
         on(:ok) do
-          Rails.logger.info "UpdateMetadata: --- INFO: USER #id: #{user.id} -> Authorization updated at: #{Decidim::Authorization.find_by(decidim_user_id: user.id).updated_at}"
+          Rails.logger.info "UpdateMetadata: --- INFO: USER #id: #{user.id} -> Authorization updated at: #{Decidim::Authorization.find_by(decidim_user_id: user.id, name: "sap_authorization_handler").updated_at}"
         end
         on(:invalid) do
           Rails.logger.info "UpdateMetadata: --- INFO: authorization is invalid and can't be created for the user #id: #{user.id}."

--- a/spec/controllers/assemblies_controller_spec.rb
+++ b/spec/controllers/assemblies_controller_spec.rb
@@ -10,7 +10,7 @@ module Decidim
       let(:organization) { create(:organization) }
       let(:current_user) { create(:user, :confirmed, organization: organization) }
       let(:metadata) { { ceco: "ceco", ceco_txt: "ceco_txt" } }
-      let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+      let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
 
       let!(:published) do
         create(
@@ -59,7 +59,7 @@ module Decidim
       describe "promoted_assemblies" do
         context "when user is admin" do
           let!(:current_user) { create(:user, :admin, :confirmed, organization: organization) }
-          let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+          let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
 
           it "includes all promoted" do
             expect(controller.helpers.promoted_assemblies).to include(promoted)
@@ -89,7 +89,7 @@ module Decidim
 
         context "when user is admin" do
           let!(:current_user) { create(:user, :admin, :confirmed, organization: organization) }
-          let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+          let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
 
           it "includes all parent assemblies" do
             expect(controller.helpers.parent_assemblies).to include(promoted)

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:organization) { create(:organization) }
       let(:metadata) { { ceco: "ceco", ceco_txt: "ceco_txt" } }
-      let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+      let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
       let!(:space_with_other_permissions) do
         create(
           :participatory_process,

--- a/spec/controllers/components_controller_spec.rb
+++ b/spec/controllers/components_controller_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:organization) { create(:organization) }
       let(:metadata) { { ceco: "ceco", ceco_txt: "ceco_txt" } }
-      let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+      let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
 
       let!(:space_with_permissions) do
         create(

--- a/spec/controllers/consultations_controller_spec.rb
+++ b/spec/controllers/consultations_controller_spec.rb
@@ -10,7 +10,7 @@ module Decidim
       let(:organization) { create(:organization) }
       let(:current_user) { create(:user, :confirmed, organization: organization) }
       let(:metadata) { { ceco: "ceco", ceco_txt: "ceco_txt" } }
-      let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+      let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
 
       let!(:published_with_permissions) do
         create(
@@ -47,7 +47,7 @@ module Decidim
       describe "published_consultations" do
         context "when user is admin" do
           let!(:current_user) { create(:user, :admin, :confirmed, organization: organization) }
-          let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+          let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
 
           it "includes all consultations" do
             expect(controller.helpers.consultations).to include(published_with_permissions)

--- a/spec/controllers/participatory_processes_controller_spec.rb
+++ b/spec/controllers/participatory_processes_controller_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       let(:organization) { create(:organization) }
       let(:current_user) { create(:user, :confirmed, organization: organization) }
       let(:metadata) { { ceco: "ceco", ceco_txt: "ceco_txt" } }
-      let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+      let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
       let!(:promoted) do
         create(
           :participatory_process,
@@ -50,7 +50,7 @@ module Decidim
       describe "promoted_participatory_processes" do
         context "when user is admin" do
           let!(:current_user) { create(:user, :admin, :confirmed, organization: organization) }
-          let!(:authorization) { create(:authorization, user: current_user, name: "dummy_authorization_handler", metadata: metadata) }
+          let!(:authorization) { create(:authorization, user: current_user, name: "sap_authorization_handler", metadata: metadata) }
 
           it "includes all promoted" do
             expect(controller.helpers.collection).to include(promoted)


### PR DESCRIPTION
#### :tophat: What? Why?
`app/permissions/suara_permissions_supervisor.rb` was retrieving the first authorization from the user, whatever the authorization handler was.

This worked well until more authorization methods has been added.
This PR fixes the situation by retrieving only the SAP's user's authorization. That is, the one with name: "sap_authorization_handler".